### PR TITLE
Update model_loader.py

### DIFF
--- a/open_universe/inference_utils/model_loader.py
+++ b/open_universe/inference_utils/model_loader.py
@@ -114,7 +114,7 @@ def load_model(ckpt_path, device=None, strict=True, return_config=False, hf_toke
     model = instantiate(config.model, _recursive_=False)
     model = model.to(device)
 
-    data = torch.load(ckpt_path, map_location=device)
+    data = torch.load(ckpt_path, map_location=device, weights_only=False)
 
     if hasattr(model, "ema") and "ema" in data:
         model.ema.load_state_dict(data["ema"])


### PR DESCRIPTION
Hi,
Thank you for the amazing model.

From Torch 2.6, `torch.load` is set with `weights_only=True` by default, contrary to previous behaviour. (https://docs.pytorch.org/docs/stable/notes/serialization.html#weights-only)

This makes the loading of the current pretrained weights fail, as many things other than weights are currently saved there (apparently, Hydra stuff, lists, etc).

This small PR sets `weights_only=False` on `torch.load`, which fixes the loading.

Hope it makes sense and helps.
